### PR TITLE
#issue JO-592

### DIFF
--- a/formazione/elenchi.py
+++ b/formazione/elenchi.py
@@ -12,7 +12,7 @@ class ElencoPartecipantiCorsiBase(ElencoVistaAnagrafica):
 
     def excel_colonne(self):
         return super(ElencoPartecipantiCorsiBase, self).excel_colonne() + (
-            ("Stato", lambda p: 'Iscritto' if not p.aspirante or self.args[0][0].pk not in p.aspirante.inviti_attivi else 'Invitato'),
+            ("Stato", lambda p: self.args[0][0].pk),
         )
 
     def risultati(self):

--- a/ufficio_soci/viste.py
+++ b/ufficio_soci/viste.py
@@ -30,6 +30,7 @@ from ufficio_soci.forms import ModuloCreazioneEstensione, ModuloAggiungiPersona,
     ModuloCreazioneRiserva, ModuloCreazioneTrasferimento, ModuloQuotaVolontario, ModuloNuovaRicevuta, ModuloFiltraEmissioneTesserini, \
     ModuloLavoraTesserini, ModuloScaricaTesserini, ModuloDimissioniSostenitore
 from ufficio_soci.models import Quota, Tesseramento, Tesserino, Riduzione
+from formazione.models import PartecipazioneCorsoBase
 
 
 @pagina_privata(permessi=(GESTIONE_SOCI,))
@@ -663,6 +664,14 @@ def us_elenco_download(request, me, elenco_id):
             })
 
         persona_colonne = [y if y is not None else "" for y in [x(persona) for x in colonne]]
+        torna_utente = Persona.objects.get(codice_fiscale=persona_colonne[2])
+        try:
+            partecipazione = PartecipazioneCorsoBase.objects.get(persona_id=torna_utente.pk,
+                                                                 corso_id=persona_colonne[len(persona_colonne)-1])
+            stato_iscrizione = "Iscritto"
+        except PartecipazioneCorsoBase.DoesNotExist:
+            stato_iscrizione = "Invitato"
+        persona_colonne[len(persona_colonne)-1] = stato_iscrizione
         if not fogli_multipli:
             persona_colonne += [elenco.excel_foglio(persona)]
 


### PR DESCRIPTION
#issue JO-592:
nel codice di back-end è previsto l'ottenimento dello stato dell'iscritto (invitato o iscritto) nel file "elenchi.py". Tuttavia viene usata la tabella aspirante in cui non ci sono le relative occorrenze di generiche persone iscritte (es.: i sostenitori che non passano dal processo aspirante) e ciò causa l'errore 500.
La soluzione che propongo è quella di prendere l'informazione dello stato dell'iscritto dalla tabella partecipazionecorsobase del database. Se l'iscritto presenta la relativa occorrenza in questa tabella il suo stato è "iscritto" altrimenti è "invitato".

## Motivazione

Una breve descrizione del contesto e della motivazione di questo cambiamento. Includi qui tutti i riferimenti a eventuali issue su JIRA o regolamenti CRI.


## Analisi

Descrivi come dalla motivazione e dal contesto descritto sopra sei arrivato a questa soluzione.


## Cambiamenti

Un elenco dei cambiamenti introdotti da questa PR. Questi devono essere espressi dal punto di vista dell'utente (es.: "L'utente può richiedere una estensione di servizio, attraverso [...]"), oppure dal punto di vista del sistema (es.: "Il sistema cancella automaticamente i commenti più vecchi di una settimana.").


## Limitazioni

Se applicabile, includi qui un elenco di test che non è ti è stato possibile effettuare e perché), problemi noti di questa soluzione, lavoro successivo che sarà necessario in seguito all'accettazione di questa PR (nota bene: è tua responsabilità creare il task relativo su JIRA).


## Testing effettuato

Un elenco dettagliato e completo del testing che hai effettuato in autonomia. Se hai introdotto delle nuove funzionalità, includi i dettagli dei test funzionali che le accompagnano.

